### PR TITLE
Adds Requirement Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@
 ##### You can also set the default languages and the default Linguee website from Ulauncher preferences.
 
 ![Linguee config](lingUee-config.png)
+
+## 🔧 Requirements
+
+This extension requires Python 3 and the **BeautifulSoup4** library.
+
+### Installing the dependency
+
+If you're using Debian or Ubuntu, you can install it via APT:
+
+```bash
+sudo apt install python3-bs4
+```


### PR DESCRIPTION
I had the error below when I tried the first time:

```
Traceback (most recent call last):
  File "~/.local/share/ulauncher/extensions/com.github.foersterrobert.linguee/main.py", line 10, in <module>
    from bs4 import BeautifulSoup
ModuleNotFoundError: No module named 'bs4'
```